### PR TITLE
Fixing a minor bug in the VM stats worker

### DIFF
--- a/src/dogstatsd_vm_stats.erl
+++ b/src/dogstatsd_vm_stats.erl
@@ -67,7 +67,7 @@ init(BaseKey) ->
     {{input,In},{output,Out}} = erlang:statistics(io),
     PrevGC = erlang:statistics(garbage_collection),
     case {sched_time_available(), stillir:get_config(dogstatsd, vm_stats_scheduler)} of
-        {true, {ok,true}} ->
+        {true, true} ->
             {ok, #state{key = [BaseKey,$.],
                         timer_ref = Ref,
                         delay = Delay,


### PR DESCRIPTION
That would cause it to be disabled by default
