### PR TITLE
Adding support for events

### DIFF
--- a/src/dogstatsd.erl
+++ b/src/dogstatsd.erl
@@ -6,6 +6,12 @@
 -type metric_sample_rate() :: number().
 -type metric_tags() :: map().
 
+-type event_title() :: iodata().
+-type event_text() :: iodata().
+-type event_type() :: info | error | warning | success.
+-type event_priority() :: normal | low.
+-type event_tags() :: map().
+
 -export_type([
               metric_name/0
              ,metric_value/0
@@ -15,38 +21,44 @@
              ]).
 
 -export([
-         send/5
-        ,gauge/2, gauge/3, gauge/4
+        gauge/2, gauge/3, gauge/4
         ,counter/2, counter/3, counter/4
         ,increment/2, increment/3, increment/4
         ,histogram/2, histogram/3, histogram/4
         ,timer/2, timer/3, timer/4
         ,timing/2, timing/3, timing/4
         ,set/2, set/3, set/4
+        ,event/1, event/2, event/3, event/4, event/5
         ]).
 
+-spec send_metric(metric_type(), metric_name(), metric_value(), metric_sample_rate(), metric_tags()) -> ok.
+send_metric(Type, Name, Value, SampleRate, Tags) ->
+    send({metric, {Type, Name, Value, SampleRate, Tags}}).
 
--spec send(metric_type(), metric_name(), metric_value(), metric_sample_rate(), metric_tags()) -> ok.
-send(Type, Name, Value, SampleRate, Tags) ->
-    wpool:cast(dogstatsd_worker, {Type, Name, Value, SampleRate, Tags}).
+-spec send_event(event_title(), event_text(), event_type(), event_priority(), event_tags()) -> ok.
+send_event(Title, Text, Type, Priority, Tags) ->
+    send({event, {Title, Text, Type, Priority, Tags}}).
 
+-spec send({atom(), {any()}}) -> ok.
+send(Data) ->
+    wpool:cast(dogstatsd_worker, Data).
 
 -define(SPEC_TYPE_2(Type), -spec Type(metric_name(), metric_value()) -> ok).
 -define(MK_TYPE_2(Type),
         Type(Name, Value) ->
-               send(Type, Name, Value, 1.0, #{})
+               send_metric(Type, Name, Value, 1.0, #{})
 ).
 -define(SPEC_TYPE_3(Type), -spec Type(metric_name(), metric_value(), metric_sample_rate()|metric_tags()) -> ok).
 -define(MK_TYPE_3(Type),
         Type(Name, Value, SampleRate) when is_number(SampleRate) ->
-               send(Type, Name, Value, SampleRate, #{});
+               send_metric(Type, Name, Value, SampleRate, #{});
         Type(Name, Value, Tags) when is_map(Tags) ->
-               send(Type, Name, Value, 1.0, Tags)
+               send_metric(Type, Name, Value, 1.0, Tags)
 ).
 -define(SPEC_TYPE_4(Type), -spec Type(metric_name(), metric_value(), metric_sample_rate(), metric_tags()) -> ok).
 -define(MK_TYPE_4(Type),
         Type(Name, Value, SampleRate, Tags) when is_number(SampleRate), is_map(Tags) ->
-               send(Type, Name, Value, SampleRate, Tags)
+               send_metric(Type, Name, Value, SampleRate, Tags)
 ).
 
 -define(ALIAS_TYPE_2(Alias, Real), Alias(A, B) -> Real(A, B)).
@@ -93,3 +105,15 @@ send(Type, Name, Value, SampleRate, Tags) ->
 ?MK_TYPE_2(set).
 ?MK_TYPE_3(set).
 ?MK_TYPE_4(set).
+
+-spec event(event_title()) -> ok.
+event(Title) -> event(Title, "").
+-spec event(event_title(), event_text()) -> ok.
+event(Title, Text) -> event(Title, Text, info).
+-spec event(event_title(), event_text(), event_type()) -> ok.
+event(Title, Text, Type) -> event(Title, Text, Type, normal).
+-spec event(event_title(), event_text(), event_type(), event_priority()) -> ok.
+event(Title, Text, Type, Priority) -> event(Title, Text, Type, Priority, #{}).
+-spec event(event_title(), event_text(), event_type(), event_priority(), event_tags()) -> ok.
+event(Title, Text, Type, Priority, Tags) ->
+    send_event(Title, Text, Type, Priority, Tags).


### PR DESCRIPTION
- `dogstatsd:send` shouldn't be a public function
- added some unit tests on `dogstatsd_worker`
- these unit tests uncovered a bug when reporting float metric values;
  now casting values and intervals to floats
