### PR TITLE
Exiting earlier in the worker when disabled

### DIFF
--- a/src/dogstatsd_worker.erl
+++ b/src/dogstatsd_worker.erl
@@ -49,9 +49,11 @@ handle_call(_Request, _From, State) ->
     Reply = ok,
     {reply, Reply, State}.
 
+handle_cast(Data, #state{socket = no_send} = State) ->
+    {noreply, State};
 handle_cast(Data, State) ->
     Line = build_line(Data, State),
-    send_line(Line, State),
+    ok = send_line(Line, State),
     {noreply, State}.
 
 handle_info(_Info, State) ->
@@ -98,8 +100,6 @@ build_tag_line(Tags, #state{tags=GlobalTags}) ->
               [],
               maps:merge(GlobalTags, Tags)).
 
-send_line(_, #state{socket = no_send}) ->
-    ok;
 send_line(Line, #state{socket = Socket, host = Host, port = Port}) ->
     ok = gen_udp:send(Socket, Host, Port, Line).
 


### PR DESCRIPTION
Otherwise the state would not get populated, but still lines would
be built, which would result in crashes along the lines of

```
2016-03-15_23:48:05.78357 23:48:05.753 [error] CRASH REPORT Process 'wpool_pool-dogstatsd_worker-5' with 0 neighbours exited with reason: bad argument in call to io_lib:format("~s:~.3f|~s|@~.2f", [undefined, ...
```
