### PR TITLE
Handful of small updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ _*
 *.plt
 *.swp
 *.swo
+.#*
 .erlang.cookie
 ebin
 log
@@ -18,4 +19,3 @@ _tdeps
 logs
 /_build
 /deps
-

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,9 @@
 Copyright (C) 2016– WHOOP
 
+This is the AGPLv3 license with additional permissions granted to make it
+function similar to the LGPL license.
+
+
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU Affero General Public License as published by the Free
 Software Foundation, either version 3 of the License, or any later version.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,5 +1,2 @@
-[{<<"stillir">>,
-  {git,"https://github.com/heroku/stillir.git",
-       {ref,"71cd4803bf7105927e0706a59bc2d6c8c328e072"}},
-  0},
+[{<<"stillir">>,{pkg,<<"stillir">>,<<"1.0.0">>},0},
  {<<"worker_pool">>,{pkg,<<"worker_pool">>,<<"1.0.4">>},0}].

--- a/src/dogstatsd_app.erl
+++ b/src/dogstatsd_app.erl
@@ -13,9 +13,9 @@ configure() ->
     Config = [
               {agent_address, "AGENT_ADDRESS", [{default, "localhost"}]}
              ,{agent_port, "AGENT_PORT", [{default, 8125}, {transform, integer}]}
-             ,{send_metrics, "SEND_METRICS", [{default, true}, {transform, fun transform_boolean/1}]}
              ,{global_prefix, "GLOBAL_PREFIX", [{default, ""}]}
              ,{global_tags, "GLOBAL_TAGS", [{default, #{}}, {transform, fun transform_map/1}]}
+             ,{send_metrics, "SEND_METRICS", [{default, true}, {transform, fun transform_boolean/1}]}
              ,{vm_stats, "VM_STATS", [{default, true}, {transform, fun transform_boolean/1}]}
              ,{vm_stats_delay, "VM_STATS_DELAY", [{default, 60000}, {transform, integer}]}
              ,{vm_stats_scheduler, "VM_STATS_SCHEDULER", [{default, true}, {transform, fun transform_boolean/1}]}

--- a/src/dogstatsd_vm_stats.erl
+++ b/src/dogstatsd_vm_stats.erl
@@ -156,8 +156,8 @@ handle_info({timeout, R, ?TIMER_MSG}, S = #state{key=K, delay=D, timer_ref=R}) -
             NewSched = lists:sort(erlang:statistics(scheduler_wall_time)),
             [begin
                 SSid = integer_to_list(Sid),
-                dogstatsd:timing([K,"scheduler_wall_time.",SSid,".active"], Active, 1.00),
-                dogstatsd:timing([K,"scheduler_wall_time.",SSid,".total"], Total, 1.00)
+                dogstatsd:timing([K,"scheduler_wall_time.active"], Active, 1.00, #{scheduler => SSid}),
+                dogstatsd:timing([K,"scheduler_wall_time.total"], Total, 1.00, #{scheduler => SSid})
              end
              || {Sid, Active, Total} <- wall_time_diff(PrevSched, NewSched)],
             {noreply, S#state{timer_ref=erlang:start_timer(D, self(), ?TIMER_MSG),


### PR DESCRIPTION
Mostly changes the VM stats to send the scheduler ID as a tag instead of part of the metric name.
