### PR TITLE
Update worker_pool dependency 

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Dogstatsd do
 
     def project do
       [app: :dogstatsd,
-       version: "0.5.1",
+       version: "0.7.0",
        elixir: "~> 1.2",
        build_embedded: Mix.env == :prod,
        start_permanent: Mix.env == :prod,
@@ -48,8 +48,8 @@ defmodule Dogstatsd do
     defp deps do
       [
         {:stillir, "~> 1.0.0"},
-        {:worker_pool, "~> 1.0.4"},
-        {:meck, "~> 0.8.4"} # , only: :test}
+        {:worker_pool, "~> 2.1"},
+        {:meck, "~> 0.8.4" , only: :test}
       ]
     end
   end


### PR DESCRIPTION
The old version of worker_pool doesn't compile on `Erlang/OTP 19 [erts-8.0.2]`

```
===> Compiling worker_pool
===> Compiling src/wpool_pool.erl failed
src/wpool_pool.erl:79: random:uniform/1: the 'random' module is deprecated; use the 'rand' module instead
src/wpool_pool.erl:263: random:uniform/1: the 'random' module is deprecated; use the 'rand' module instead
src/wpool_pool.erl:336: erlang:now/0: Deprecated BIF. See the "Time and Time Correction in Erlang" chapter of the ERTS User's Guide for more information.
src/wpool_pool.erl:336: random:seed/1: the 'random' module is deprecated; use the 'rand' module instead

** (Mix) Could not compile dependency :worker_pool, "/Users/milad/.mix/rebar3 bare compile --paths "/Users/milad/dev/member-center/_build/dev/lib/*/ebin"" command failed. You can recompile this dependency with "mix deps.compile worker_pool", update it with "mix deps.update worker_pool" or clean it with "mix deps.clean worker_pool
```
