### PR TITLE
resolve agent ip on init

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -1,0 +1,8 @@
+{"1.1.0",
+[{<<"stillir">>,{pkg,<<"stillir">>,<<"1.0.0">>},0},
+ {<<"worker_pool">>,{pkg,<<"worker_pool">>,<<"2.1.0">>},0}]}.
+[
+{pkg_hash,[
+ {<<"stillir">>, <<"9E77EAADD2418A61EC7398C01E29DEA26D14F51C42E0B309084493E3ED33337A">>},
+ {<<"worker_pool">>, <<"6A5C16DDC93705FEBA768F1489EF1CF0D3C787EFDAA7008684D67130E8697891">>}]}
+].

--- a/src/dogstatsd_worker.erl
+++ b/src/dogstatsd_worker.erl
@@ -33,9 +33,10 @@ init([]) ->
     State = case stillir:get_config(dogstatsd, send_metrics) of
                 true ->
                     {ok, Socket} = gen_udp:open(0),
+                    {ok, Ip} = inet:getaddr(stillir:get_config(dogstatsd, agent_address), inet),
                     #state{
                        socket = Socket,
-                       host = stillir:get_config(dogstatsd, agent_address),
+                       host = Ip,
                        port = stillir:get_config(dogstatsd, agent_port),
                        prefix = stillir:get_config(dogstatsd, global_prefix),
                        tags = stillir:get_config(dogstatsd, global_tags)


### PR DESCRIPTION
to avoid millions of lookups to an adress that will almost never change. dns round robin should help the worker pool balance across all agents at the hostname.

@capodilupo @jblanchette 